### PR TITLE
Add Bearer auth support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsql-client"
-version = "0.5.10"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "HTTP-based client for libSQL and sqld"


### PR DESCRIPTION
`reqwest` and `workers` backends can now use a `LIBSQL_CLIENT_TOKEN` env variable (or secret, respectively) to use Bearer auth. Bearer auth is preferred over Basic one, so if both a token and user/pass are present, token is picked.