### PR TITLE
chore: dependency upgrade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,27 +10,27 @@ repository = "https://github.com/libsql/libsql-client-rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-url = "2.3.1"
-base64 = "0.21.0"
-num-traits = "0.2.15"
-serde_json = "1.0.91"
-worker = { version = "0.0.12", optional = true }
-spin-sdk = { version = "1.3", git = "https://github.com/fermyon/spin", tag = "v1.3.0", default-features = false, optional = true }
-sqlite3-parser = { version = "0.8.0", default-features = false, features = [ "YYNOERRORRECOVERY" ] }
-http = { version = "0.2", optional = true }
+url = "2.4.0"
+base64 = "0.21.2"
+num-traits = "0.2.16"
+serde_json = "1.0.103"
+worker = { version = "0.0.17", optional = true }
+spin-sdk = { version = "1.4.1", git = "https://github.com/fermyon/spin", tag = "v1.4.1", default-features = false, optional = true }
+sqlite3-parser = { version = "0.9.0", default-features = false, features = [ "YYNOERRORRECOVERY" ] }
+http = { version = "0.2.9", optional = true }
 bytes = { version = "1.4.0", optional = true }
-anyhow = "1.0.69"
-reqwest = { version = "0.11.14", optional = true, default-features = false, features = ["rustls-tls"] }
-rusqlite = { version = "0.28.0", optional = true, default-features = false, features = [
+anyhow = "1.0.72"
+reqwest = { version = "0.11.18", optional = true, default-features = false, features = ["rustls-tls"] }
+rusqlite = { version = "0.29.0", optional = true, default-features = false, features = [
     "column_decltype"
 ] }
-hrana-client = { version = "0.3", optional = true }
-hrana-client-proto = { version = "0.2" }
-futures-util = { version = "0.3.21", optional = true }
-serde = "1.0.159"
+hrana-client = { version = "0.3.2", optional = true }
+hrana-client-proto = { version = "0.2.1" }
+futures-util = { version = "0.3.28", optional = true }
+serde = "1.0.174"
 tracing = "0.1.37"
 futures = "0.3.28"
-fallible-iterator = "0.2.0"
+fallible-iterator = "0.3.0"
 
 [features]
 default = ["local_backend", "hrana_backend", "reqwest_backend", "mapping_names_to_values_in_rows"]
@@ -43,7 +43,7 @@ separate_url_for_queries = []
 mapping_names_to_values_in_rows = []
 
 [dev-dependencies]
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1.29.1", features = ["full"] }
 libsql-client = { path = "." }
 rand = "0.8.5"
 tracing-subscriber = "0.3.17"


### PR DESCRIPTION
This dependency upgrade is mainly required for cloudflare workers, where if you are using a version newer than `0.0.12`, there is a linker error. This has been majorly untested though so I need to test it before marking it ready