### PR TITLE
Add from_row support

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -1,3 +1,5 @@
+//! libsql deserialization utilities.
+
 use serde::de::{value::Error as DeError, Error};
 use std::collections::hash_map::Iter;
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -190,6 +190,5 @@ mod tests {
         assert!(foo.baf > 41.0);
         assert!(foo.baf2 > 42.0);
         assert_eq!(foo.bab, vec![6u8; 128]);
-        assert_eq!(foo.ban, ());
     }
 }

--- a/src/de.rs
+++ b/src/de.rs
@@ -8,7 +8,8 @@ use serde::{
 
 use crate::Row;
 
-fn from_row<'de, T: Deserialize<'de>>(row: &'de Row) -> anyhow::Result<T> {
+/// Deserialize from a [`Row`] into any type `T` that implements `Deserialize`.
+pub fn from_row<'de, T: Deserialize<'de>>(row: &'de Row) -> anyhow::Result<T> {
     let de = De { row };
     T::deserialize(de).map_err(Into::into)
 }
@@ -105,7 +106,6 @@ impl<'de> Deserializer<'de> for V<'de> {
                 let seq = SeqDeserializer::new(value.iter().cloned());
                 visitor.visit_seq(seq)
             }
-            _ => todo!(),
         }
     }
 
@@ -155,6 +155,12 @@ mod tests {
         );
         row.value_map.insert("ban".to_string(), Value::Null);
 
-        from_row::<Foo>(&row).unwrap();
+        let foo = from_row::<Foo>(&row).unwrap();
+
+        assert_eq!(&foo.bar, &"foo");
+        assert_eq!(foo.baz, 42);
+        assert!(foo.baf > 41.0);
+        assert_eq!(foo.bab, vec![6u8; 128]);
+        assert_eq!(foo.ban, ());
     }
 }

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,0 +1,160 @@
+use std::collections::hash_map::Iter;
+
+use hrana_client_proto::Value;
+use serde::{
+    de::{value::SeqDeserializer, IntoDeserializer, MapAccess, Visitor},
+    Deserialize, Deserializer,
+};
+
+use crate::Row;
+
+fn from_row<'de, T: Deserialize<'de>>(row: &'de Row) -> anyhow::Result<T> {
+    let de = De { row };
+    T::deserialize(de).map_err(Into::into)
+}
+
+struct De<'de> {
+    row: &'de Row,
+}
+
+impl<'de> Deserializer<'de> for De<'de> {
+    type Error = serde::de::value::Error;
+
+    fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        // visitor.visit_map(RowV { row: &self.row })
+        todo!()
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        name: &'static str,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        println!("{}, {:?}", name, fields);
+
+        struct MapA<'a> {
+            iter: Iter<'a, String, Value>,
+            value: Option<&'a Value>,
+        }
+
+        impl<'de> MapAccess<'de> for MapA<'de> {
+            type Error = serde::de::value::Error;
+
+            fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
+            where
+                K: serde::de::DeserializeSeed<'de>,
+            {
+                if let Some((k, v)) = self.iter.next() {
+                    self.value = Some(v);
+                    seed.deserialize(k.to_string().into_deserializer())
+                        .map(Some)
+                } else {
+                    Ok(None)
+                }
+            }
+
+            fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
+            where
+                V: serde::de::DeserializeSeed<'de>,
+            {
+                let value = self
+                    .value
+                    .take()
+                    .expect("next_value called before next_key");
+
+                seed.deserialize(V(value))
+            }
+        }
+
+        visitor.visit_map(MapA {
+            iter: self.row.value_map.iter(),
+            value: None,
+        })
+    }
+
+    serde::forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        tuple_struct map enum identifier ignored_any
+    }
+}
+
+struct V<'a>(&'a Value);
+
+impl<'de> Deserializer<'de> for V<'de> {
+    type Error = serde::de::value::Error;
+
+    #[inline]
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.0 {
+            Value::Text { value } => visitor.visit_string(value.to_string()),
+            Value::Null => visitor.visit_unit(),
+            Value::Integer { value } => visitor.visit_i64(*value),
+            Value::Float { value } => visitor.visit_f64(*value),
+            Value::Blob { value } => {
+                let seq = SeqDeserializer::new(value.iter().cloned());
+                visitor.visit_seq(seq)
+            }
+            _ => todo!(),
+        }
+    }
+
+    serde::forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        tuple_struct map enum struct identifier ignored_any
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    #[derive(serde::Deserialize)]
+    struct Foo {
+        bar: String,
+        baz: i64,
+        baf: f64,
+        bab: Vec<u8>,
+        ban: (),
+    }
+
+    #[test]
+    fn smoke() {
+        let mut row = Row {
+            values: Vec::new(),
+            value_map: HashMap::new(),
+        };
+        row.value_map.insert(
+            "bar".to_string(),
+            Value::Text {
+                value: "foo".into(),
+            },
+        );
+        row.value_map
+            .insert("baz".to_string(), Value::Integer { value: 42 });
+        row.value_map
+            .insert("baf".to_string(), Value::Float { value: 42.0 });
+        row.value_map.insert(
+            "bab".to_string(),
+            Value::Blob {
+                value: vec![6u8; 128],
+            },
+        );
+        row.value_map.insert("ban".to_string(), Value::Null);
+
+        from_row::<Foo>(&row).unwrap();
+    }
+}

--- a/src/de.rs
+++ b/src/de.rs
@@ -11,6 +11,17 @@ use crate::Row;
 
 /// Deserialize from a [`Row`] into any type `T` that implements [`serde::Deserialize`].
 ///
+/// # Types
+///
+/// Structs must match their field name to the column name but the order does not matter.
+/// There is a limited set of Rust types which are supported and those are:
+///
+/// - String
+/// - Vec<u8>
+/// - i64
+/// - f64
+/// - ()
+///
 /// # Example
 ///
 /// ```no_run
@@ -147,6 +158,7 @@ mod tests {
     use super::*;
 
     #[derive(serde::Deserialize)]
+    #[allow(unused)]
     struct Foo {
         bar: String,
         baf: f64,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ pub use statement::Statement;
 pub mod proto;
 pub use proto::{BatchResult, Col, Value};
 
-mod de;
+pub mod de;
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 /// Represents a row returned from the database.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,8 @@ pub use statement::Statement;
 pub mod proto;
 pub use proto::{BatchResult, Col, Value};
 
+mod de;
+
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 /// Represents a row returned from the database.
 pub struct Row {


### PR DESCRIPTION
This adds basic serde support for going from a `Row` into any user struct that has field types that match Value's enum types. Other types like lists can be supported but this is out of scope of this PR.

```rust
// With some arbitrary `Row`
struct MyModel {
   bar: String,
} 

let data = libsql_client::de::from_row::<MyModel>(&row)?;

println!("{}", data.bar);
```

cc @glommer 