### PR TITLE
update cloudflare worker dep to 0.0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ url = "2.3.1"
 base64 = "0.21.0"
 num-traits = "0.2.15"
 serde_json = "1.0.91"
-worker = { version = "0.0.12", optional = true }
+worker = { version = "0.0.18", optional = true }
 spin-sdk = { version = "1.4", git = "https://github.com/fermyon/spin", tag = "v1.4.1", default-features = false, optional = true }
 sqlite3-parser = { version = "0.8.0", default-features = false, features = [ "YYNOERRORRECOVERY" ] }
 http = { version = "0.2", optional = true }


### PR DESCRIPTION
When trying to use `libsql-client` within a Cloudflare Worker environment I get this

```
error[E0432]: unresolved imports `syn::FnArg`, `syn::ImplItem`, `syn::Item`
 --> /home/aifrim/.cargo/registry/src/index.crates.io-6f17d22bba15001f/worker-macros-0.0.6/src/durable_object.rs:3:36
  |
3 | use syn::{spanned::Spanned, Error, FnArg, ImplItem, Item, Type, TypePath};
  |                                    ^^^^^  ^^^^^^^^  ^^^^ no `Item` in the root
  |                                    |      |
  |                                    |      no `ImplItem` in the root
  |                                    no `FnArg` in the root

error[E0432]: unresolved import `syn::ItemFn`
 --> /home/aifrim/.cargo/registry/src/index.crates.io-6f17d22bba15001f/worker-macros-0.0.6/src/event.rs:3:75
  |
3 | use syn::{parse_macro_input, punctuated::Punctuated, token::Comma, Ident, ItemFn};
  |                                                                           ^^^^^^ no `ItemFn` in the root

For more information about this error, try `rustc --explain E0432`.
```

Here is how it is defined in my `Cargo.toml` (since the latest changes 
```toml
[dependencies]
libsql-client = { version = "0.31.10", default-features = false, features = [
    "worker",
    "workers_backend",
    "mapping_names_to_values_in_rows",
], git = "https://github.com/libsql/libsql-client-rs" }
```

And when I change the git url to my fork https://github.com/aifrim/libsql-client-rs the build works.