### PR TITLE
Bump up Spin 2.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ base64 = "0.21.0"
 num-traits = "0.2.15"
 serde_json = "1.0.91"
 worker = { version = "0.0.18", optional = true }
-spin-sdk = { version = "1.5", git = "https://github.com/fermyon/spin", tag = "v1.5.0", default-features = false, optional = true }
+spin-sdk = { version = "2.0", git = "https://github.com/fermyon/spin", tag = "v2.0.0", default-features = false, optional = true }
 sqlite3-parser = { version = "0.8.0", default-features = false, features = [ "YYNOERRORRECOVERY" ] }
 http = { version = "0.2", optional = true }
 bytes = { version = "1.4.0", optional = true }


### PR DESCRIPTION
Spin 2 came out(https://www.fermyon.com/blog/introducing-spin-v2). 
Bumping its version to 2. 
Passed all `cargo test`. 
