### PR TITLE
fix: http client execute multiple server responses error

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -213,7 +213,8 @@ impl Client {
                 response.results
             );
         }
-        if response.results.len() > 1 {
+        if response.results.len() > 2 {
+            // One with actual results, one closing the stream
             anyhow::bail!(
                 "Unexpected multiple responses from server: {:?}",
                 response.results


### PR DESCRIPTION
http client execute function is returning two responses: results AND close stream. (raw_batch already had this change, both calling the same underlying method).

this fixes the response size verification.
